### PR TITLE
Prevent Renovate from rebasing stale PRs during work hours.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "semanticCommits": true,
       "timezone": "America/Los_Angeles",
       "schedule": ["after 6pm and before 5am on every weekday"],
-      "rebaseStalePrs": true,
+      "rebaseStalePrs": false,
       "prCreation": "not-pending",
       "automerge": "minor",
       "labels": ["dependencies"],


### PR DESCRIPTION
Although this Renovate configuration attempts to restrict activity to non-work hours, Renovate apparently has no qualms about rebasing PRs (and thus re-running tests) any time of the day. For example: https://github.com/apollographql/apollo-tooling/pull/1037

I propose we disable this behavior, since we can easily request a rebase by clicking the checkbox any time we like.