### PR TITLE
Only rebase PRs on the weekends, unless they're `apollo*` packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "timezone": "America/Los_Angeles",
       "schedule": "every weekend",
       "rebaseStalePrs": true,
+      "updateNotScheduled": false,
       "prCreation": "not-pending",
       "automerge": "minor",
       "labels": ["dependencies"],

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "labels": ["dependencies"],
       "packageRules": [
         {
-          "packagePatterns": ["^apollo"],
+          "packagePatterns": ["apollo"],
           "schedule": "at any time"
         },
         {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,16 @@
       "extends": [":pinOnlyDevDependencies"],
       "semanticCommits": true,
       "timezone": "America/Los_Angeles",
-      "schedule": ["after 6pm and before 5am on every weekday"],
+      "schedule": "every weekend",
       "rebaseStalePrs": true,
       "prCreation": "not-pending",
       "automerge": "minor",
       "labels": ["dependencies"],
       "packageRules": [
+        {
+          "packagePatterns": ["^apollo"],
+          "schedule": "at any time"
+        },
         {
           "packagePatterns": ["event-stream"],
           "enabled": false


### PR DESCRIPTION
This is a slightly different proposal for #1.  I left some comments (https://github.com/apollographql/renovate-config-apollo-open-source/pull/1#issuecomment-470022944 and below it https://github.com/apollographql/renovate-config-apollo-open-source/pull/1#issuecomment-470023657) with my thoughts on disabling `rebaseStalePrs` entirely.

This PR aims to take a different approach which I think should stay out of the way by making that rebase behavior confine itself to the weekends... **with the exception of packages which start with `apollo`**, which I think it's ideal to merge into our repositories as soon as possible to keep a pulse on things happening in other repositories which might affect other `apollo-*` repos.

The commit messages on this PR explain a bit more, but I'm hoping this might be a reasonable alternative since I'm not comfortable disabling `rebaseStalePrs`.