### PR TITLE
Change `event-stream` pinning to be `packageNames` not `packagePatterns`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "labels": ["dependencies"],
       "packageRules": [
         {
-          "packagePatterns": ["event-stream"],
+          "packageNames": ["event-stream"],
           "enabled": false
         }
       ]


### PR DESCRIPTION
I think we want to match the exact name `event-stream`, not any package that
has `event-stream` in it anywhere (since `packagePatterns` is treated like a
regular expression:

https://renovatebot.com/docs/configuration-options/#packagepatterns